### PR TITLE
Replace NuGet.Build.Packaging with NuGetizer

### DIFF
--- a/src/TemplateUI/TemplateUI.csproj
+++ b/src/TemplateUI/TemplateUI.csproj
@@ -15,11 +15,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.7.0.1351" />
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.5-dev.8">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="NuGetizer" Version="0.7.0">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xamarin.Forms" Version="4.7.0.1351" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
[NuGet.Build.Packaging](https://www.nuget.org/packages/NuGet.Build.Packaging/) 0.2.5-dev.8 is not available on NuGet.org and according to https://github.com/NuGet/NuGet.Build.Packaging/pull/174 it is also not maintained anymore.

As development has moved to https://github.com/devlooped/nugetizer this pull request replaces NuGet.Build.Packaging with NuGetizer.

Closes #25 